### PR TITLE
Export types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,10 @@ export {
   toQuery,
   Context
 }
+
+export type {
+  MediaQueryTypes,
+  MediaQueryType,
+  MediaQueryFeatures,
+  MediaQueryAllQueryable
+} from './types'


### PR DESCRIPTION
Small proposal to export the types from the root to get the same experience as what was available on the DefninitelyTyped protivided definitions.

This is currently doable by importing the file directly, but it would give a bit better dev-XP:

```typescript
import { useMediaQuery } from 'react-responsive';
import { MediaQueryAllQueryable } from 'react-responsive/src/types';

// vs

import { useMediaQuery, MediaQueryAllQueryable } from 'react-responsive';
```