### PR TITLE
force matchmediaquery to use the context/prop values

### DIFF
--- a/src/useMediaQuery.ts
+++ b/src/useMediaQuery.ts
@@ -62,7 +62,7 @@ const useQuery = (settings: MediaQuerySettings) => {
 }
 
 const useMatchMedia = (query: string, device: MediaQueryMatchers) => {
-  const getMatchMedia = () => matchMedia(query, device)
+  const getMatchMedia = () => matchMedia(query, device || {}, !!device)
   const [ mq, setMq ] = React.useState(getMatchMedia)
   const isUpdate = useIsUpdate()
 


### PR DESCRIPTION
This fixes #287 by replicating the previous behaviour (https://github.com/yocontra/react-responsive/blob/v8.2.0/src/useMediaQuery.js#L61) by setting `forceStatics` within `matchmediaquery`.

This does mean that useMediaQuery will always use the device from context/props if provided however this is somewhat necessary for correct SSR as the first render on the client will need to match that from the server. I recommend this workaround for that: https://github.com/yocontra/react-responsive/issues/257#issuecomment-677619268 although I'm happy to contribute a solution within this library for this (as a different pr).