### PR TITLE
force matchmediaquery to use the context/prop values

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "clean": "rimraf dist",
     "tag": "git tag -a \"v$npm_package_version\" -m \"tag version $npm_package_version\" && git push origin master --tags",
     "lint": "eslint --ext=ts,tsx src test --fix",
-    "test": "cross-env NODE_PATH=$NODE_PATkH:$PWD/src ts-node ./node_modules/.bin/mocha -R spec --require ./test/setup.js test/*_test.ts",
+    "test": "cross-env NODE_PATH=$NODE_PATkH:$PWD/src ts-node ./node_modules/.bin/mocha -R spec --require ./test/setup.js test/*_test.{ts,tsx}",
     "docs": "typedoc src/index.ts --theme minimal && gh-pages -d docs"
   },
   "engines": {

--- a/src/@types/shallow-equal.d.ts
+++ b/src/@types/shallow-equal.d.ts
@@ -13,7 +13,7 @@ declare module 'shallow-equal' {
     [key: string]: primitives;
   }
   export function shallowEqualObjects(
-    obj1: primitiveObject,
-    obj2: primitiveObject
+    obj1: primitiveObject | undefined,
+    obj2: primitiveObject | undefined
   ): boolean;
 }

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import { MediaQueryAllQueryable } from './types'
 
-const Context = React.createContext<Partial<MediaQueryAllQueryable>>({})
+const Context = React.createContext<Partial<MediaQueryAllQueryable> | undefined>(undefined)
 
 export default Context

--- a/src/useMediaQuery.ts
+++ b/src/useMediaQuery.ts
@@ -10,10 +10,9 @@ type MediaQuerySettings = Partial<MediaQueryAllQueryable & { query?: string }>
 
 const makeQuery = (settings: Record<string, any>) => settings.query || toQuery(settings)
 
-const hyphenateKeys = (obj?: Record<string, any>): Record<string, any> | null => {
-  if (!obj) return null
+const hyphenateKeys = (obj?: Record<string, any>): Record<string, any> | undefined => {
+  if (!obj) return undefined
   const keys = Object.keys(obj)
-  if (keys.length === 0) return null
 
   return keys.reduce((result, key) => {
     result[hyphenate(key)] = obj[key]
@@ -31,10 +30,10 @@ const useIsUpdate = () => {
   return ref.current
 }
 
-const useDevice = (deviceFromProps?: MediaQueryMatchers): Partial<MediaQueryAllQueryable> => {
+const useDevice = (deviceFromProps?: MediaQueryMatchers): Partial<MediaQueryAllQueryable> | undefined => {
   const deviceFromContext = React.useContext(Context)
   const getDevice = () =>
-    hyphenateKeys(deviceFromProps) || hyphenateKeys(deviceFromContext) || {}
+    hyphenateKeys(deviceFromProps) || hyphenateKeys(deviceFromContext)
   const [ device, setDevice ] = React.useState(getDevice)
 
   React.useEffect(() => {
@@ -61,8 +60,8 @@ const useQuery = (settings: MediaQuerySettings) => {
   return query
 }
 
-const useMatchMedia = (query: string, device: MediaQueryMatchers) => {
-  const getMatchMedia = () => matchMedia(query, device)
+const useMatchMedia = (query: string, device?: MediaQueryMatchers) => {
+  const getMatchMedia = () => matchMedia(query, device || {}, !!device)
   const [ mq, setMq ] = React.useState(getMatchMedia)
   const isUpdate = useIsUpdate()
 

--- a/test/Component_test.tsx
+++ b/test/Component_test.tsx
@@ -8,7 +8,7 @@ import { MatchMediaMock } from 'match-media-mock'
 
 interface MockWindow extends Window { matchMedia: MatchMediaMock; }
 
-describe('MediaQuery', () => {
+describe('Component', () => {
   beforeEach(() => {
     (window as unknown as MockWindow).matchMedia.setConfig({
       type: 'screen',
@@ -44,7 +44,7 @@ describe('MediaQuery', () => {
   })
 
   it('works with render prop', () => {
-    const renderFunc = sinon.spy()
+    const renderFunc = sinon.stub().returns(null)
     TestUtils.renderIntoDocument(
       <MediaQuery minWidth={1000}>
         {renderFunc}
@@ -53,7 +53,7 @@ describe('MediaQuery', () => {
     assert.isTrue(renderFunc.calledOnce)
     assert.isTrue(renderFunc.calledWith(true))
 
-    const renderFunc2 = sinon.spy()
+    const renderFunc2 = sinon.stub().returns(null)
     TestUtils.renderIntoDocument(
       <MediaQuery minWidth={1201}>
         {renderFunc2}

--- a/test/useMediaQuery_test.tsx
+++ b/test/useMediaQuery_test.tsx
@@ -117,7 +117,7 @@ describe('useMediaQuery', () => {
 
   it('uses query prop if it has one', () => {
     (window as unknown as MockWindow).matchMedia.setConfig({
-      orientation: 'landscape'
+      width: 500
     })
 
     function Component({ query }: any) {
@@ -129,12 +129,12 @@ describe('useMediaQuery', () => {
     }
 
     const tree = TestUtils.renderIntoDocument(
-      <App query="(orientation: landscape)" />
+      <App query="(min-width: 500)" />
     )
     assert.isNotNull(TestUtils.findRenderedDOMComponentWithClass(tree as unknown as Component, 'childComponent'))
 
     const tree2 = TestUtils.renderIntoDocument(
-      <App query="(orientation: portrait)" />
+      <App query="(min-width: 501)" />
     )
     assert.throws(() => TestUtils.findRenderedDOMComponentWithTag(tree2 as unknown as Component, 'div'), /Did not find exactly one match/)
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,9 @@
     "declaration": true,
     "esModuleInterop": true,
     "outDir": "./",
+    "paths": {
+      "shallow-equal": ["./src/@types/shallow-equal"]
+    }
   },
   "include": ["src"],
   "exclude": ["test", "node_modules"],


### PR DESCRIPTION
Previously closed PR: #288 

This fixes #287 by replicating the previous behaviour (https://github.com/yocontra/react-responsive/blob/v8.2.0/src/useMediaQuery.js#L61) by setting forceStatics within matchmediaquery.

Most of the changes were to support device being undefined instead of an empty object. Other changes were to ensure that .tsx were running and passing.

This does mean that useMediaQuery will always use the device from context/props if provided however this is somewhat necessary for correct SSR as the first render on the client will need to match that from the server. I recommend this workaround for that: #257 (comment) although I'm happy to contribute a solution within this library for this (as a different pr).