### PR TITLE
Update Component.d.ts children type

### DIFF
--- a/types/Component.d.ts
+++ b/types/Component.d.ts
@@ -2,7 +2,7 @@ import { ReactNode, FC, CSSProperties } from 'react';
 import { MediaQueryAllQueryable, MediaQueryMatchers } from './types';
 interface MediaQueryProps extends MediaQueryAllQueryable {
     component?: ReactNode;
-    children?: ReactNode | Function;
+    children?: ReactNode | ((matches: boolean) => ReactNode);
     query?: string;
     style?: CSSProperties;
     className?: string;


### PR DESCRIPTION
This improves types when render props are used. It will raise an error when you mistakenly forget to return a value:

```tsx
<MediaQuery minWidth={1200}>
	{(matches) => {matches ? <span>desktop</span> : <span>mobile</span>}}
</MediaQuery>
```

<pre>
Type '(matches: boolean) => void' is not assignable to type 'ReactNode | ((matches: boolean) => ReactNode)'.
  Type '(matches: boolean) => void' is not assignable to type '(matches: boolean) => ReactNode'.
    Type 'void' is not assignable to type 'ReactNode'.ts(2322)
</pre>

If I switch the curly brackets for parentheses, the error correctly disappears:

```tsx
<MediaQuery minWidth={1200}>
	{(matches) => (matches ? <span>desktop</span> : <span>mobile</span>)}
</MediaQuery>
```